### PR TITLE
[backend] 로그인 유저정보 확인 logic 추가.

### DIFF
--- a/backend/controllers/commentController.js
+++ b/backend/controllers/commentController.js
@@ -33,11 +33,12 @@ async function CreateComment(req, res) {
 
         const current = CookieManager.checkCurrentSession(req, res);
         // 현재 로그인이 되어있는지 확인.
-        if (current === undefined) {
+		// 로그인 사용자와 댓글 작성자의 reviewer 정보가 다르면 에러 반환.
+        if (current === undefined || current !== comment_reviewer) {
             res.status(401).json({ error: "Unauthorized access. Log in with the appropriate account." });
             return;
         }
-
+		
         await Comment.create(comment_review, comment_score, comment_reviewer, comment_time, comment_target);
         res.status(201).json({result: true});
     } catch (err) { 
@@ -63,7 +64,8 @@ async function DeleteComment(req, res) {
 
         const current = CookieManager.checkCurrentSession(req, res);
         // 현재 로그인이 되어있는지 확인.
-        if (current === undefined) {
+		// 로그인 사용자와 댓글 작성자의 reviewer 정보가 다르면 에러 반환.
+        if (current === undefined || current !== comment.comment_reviewer) {
             res.status(401).json({ error: "Unauthorized access. Log in with the appropriate account." });
             return;
         }
@@ -107,9 +109,16 @@ async function EditComment(req, res) {
             return;
         }
 
+		const comment = await this.findOne({"comment_id": comment_id});
+		if (comment === null) {
+            res.status(404).json({error: "comment with id ${comment_id} is not found."});
+            return;
+        }
+		
         const current = CookieManager.checkCurrentSession(req, res);
         // 현재 로그인이 되어있는지 확인.
-        if (current === undefined) {
+		// 로그인 사용자와 댓글 작성자의 reviewer 정보가 다르면 에러 반환.
+        if (current === undefined || current !== comment.comment_reviewer) {
             res.status(401).json({ error: "Unauthorized access. Log in with the appropriate account." });
             return;
         }

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -143,7 +143,7 @@ async function AddFavorite(req, res) {
 
 		const current = CookieManager.checkCurrentSession(req, res);
         // 현재 로그인이 되어있는지 확인.
-        if (current === undefined) {
+        if (current === undefined || current !== user_id) {
             res.status(401).json({ error: "Unauthorized access. Log in with the appropriate account." });
 			return;
         }
@@ -165,7 +165,7 @@ async function RemoveFavorite(req, res) {
 
 		const current = CookieManager.checkCurrentSession(req, res);
         // 현재 로그인이 되어있는지 확인.
-        if (current === undefined) {
+        if (current === undefined || current !== user_id) {
             res.status(401).json({ error: "Unauthorized access. Log in with the appropriate account." });
 			return;
         }

--- a/backend/models/commentModel.js
+++ b/backend/models/commentModel.js
@@ -79,8 +79,6 @@ Comment.statics.delete = async function (comment_id) {
 }
 
 Comment.statics.edit = async function (comment_id, change_review, change_score) {
-    const comment = await this.findOne({"comment_id": comment_id});
-
     this.findOneAndUpdate({"comment_id": comment_id}, {
         $set: {
             comment_review: change_review,


### PR DESCRIPTION
* API 요청 중 로그인 정보가 필요한 부분에 logic 추가.
* ex) addFavor에서 token의 유저 id와 API의 user_id가 다르면 401(auth errer)를 반환하도록 변경.